### PR TITLE
Migrate live timing client from classic SignalR to SignalR Core

### DIFF
--- a/lib/f1_bot/application.ex
+++ b/lib/f1_bot/application.ex
@@ -27,12 +27,12 @@ defmodule F1Bot.Application do
         F1Bot.TranscriberService
       ]
       |> add_if_feature_flag_enabled(:connect_to_signalr, {
-        F1Bot.ExternalApi.SignalR.Client,
+        F1Bot.ExternalApi.SignalRCore.Client,
         [
           scheme: "https",
           hostname: "livetiming.formula1.com",
-          base_path: "/signalr",
-          user_agent: "",
+          base_path: "/signalrcore",
+          user_agent: "BestHTTP",
           port: 443,
           hub: "Streaming",
           topics:

--- a/lib/f1_bot/external_api/signalr_core/client.ex
+++ b/lib/f1_bot/external_api/signalr_core/client.ex
@@ -1,0 +1,335 @@
+defmodule F1Bot.ExternalApi.SignalRCore.Client do
+  @moduledoc """
+  A SignalR client that establishes a websocket connection to the F1 live timing API and handles
+  all received events by forming `F1Bot.F1Session.LiveTimingHandlers.Packet` structs and passing them to
+  `F1Bot.F1Session.LiveTimingHandlers` for processing.
+
+  As of 2026 F1 uses ASP.NET Core SignalR (`/signalrcore`). The JSON hub protocol works as follows:
+
+    1. HTTP POST `/signalrcore/negotiate?negotiateVersion=1` -> connectionToken + AWSALB cookie
+    2. Open websocket `wss://.../signalrcore?id=<connectionToken>`
+    3. Send handshake `{"protocol":"json","version":1}\x1e`
+    4. Receive handshake ack `{}\x1e`
+    5. Invoke `{"type":1,"target":"Subscribe","arguments":[[topics]],"invocationId":"0"}\x1e`
+    6. Receive completion `{"type":3,"invocationId":"0","result":{<snapshot>}}\x1e` (initial state)
+    7. Receive feed `{"type":1,"target":"feed","arguments":[topic, data, timestamp]}\x1e`
+    8. Server/client keep-alive pings `{"type":6}\x1e`
+
+  Each message is terminated by the ASCII record separator 0x1e; a single websocket
+  frame may contain several concatenated messages.
+
+  https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/HubProtocol.md
+  """
+  use GenServer
+  require Logger
+  alias F1Bot.ExternalApi.SignalRCore
+  alias F1Bot.F1Session.LiveTimingHandlers.{Packet, ProcessingOptions}
+
+  @supervisor F1Bot.DynamicSupervisor
+
+  # SignalR Core message terminator (ASCII record separator, 0x1e)
+  @rs "\x1e"
+
+  # Must be a string, otherwise pattern matching won't work - server echoes it back as a string
+  @subscribe_command_id "0"
+
+  # No KeepAliveTimeout is provided by the Core negotiate response. The server pings
+  # roughly every 15s by default; allow a generous window before assuming a dead link.
+  @keepalive_timeout_sec 30
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def ws_handle_connected() do
+    GenServer.call(__MODULE__, {:ws_handle_connected})
+  end
+
+  def ws_handle_message(message) do
+    GenServer.call(__MODULE__, {:ws_handle_message, message})
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok, nil, {:continue, {:after_init, opts}}}
+  end
+
+  @impl true
+  def handle_continue({:after_init, opts}, _state) do
+    Logger.info("SignalR: Sleeping for 2 seconds")
+    Process.sleep(2000)
+
+    %{
+      data: negotiation_data,
+      cookies: cookies
+    } = do_negotiate_signalr_conn(opts)
+
+    state =
+      %{
+        ws_client_pid: nil,
+        state: :disconnected,
+        hostname: Keyword.fetch!(opts, :hostname),
+        scheme: Keyword.fetch!(opts, :scheme),
+        port: Keyword.fetch!(opts, :port),
+        base_path: Keyword.fetch!(opts, :base_path),
+        user_agent: Keyword.fetch!(opts, :user_agent),
+        signalr_params: %{
+          conn_id: Map.fetch!(negotiation_data, "ConnectionId"),
+          conn_token: Map.fetch!(negotiation_data, "ConnectionToken"),
+          cookies: cookies
+        },
+        hub: Keyword.fetch!(opts, :hub),
+        topics: Keyword.fetch!(opts, :topics),
+        last_keepalive: nil,
+        keepalive_timeout: @keepalive_timeout_sec
+      }
+
+    state = do_connect_ws(state)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call({:ws_handle_connected}, _from, state) do
+    Logger.info("SignalR: Connected to websocket")
+
+    state = do_send_handshake(state)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:ws_handle_message, message}, _from, state) do
+    state = do_handle_message(message, state)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:send_ping, state = %{state: :subscribed}) do
+    send_ws_message(%{type: 6})
+    {:noreply, state}
+  end
+
+  def handle_info(:send_ping, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info(
+        :signalr_init_timeout,
+        state = %{state: :awaiting_handshake}
+      ) do
+    {:stop, :signalr_init_timeout, state}
+  end
+
+  def handle_info(
+        :signalr_init_timeout,
+        state = %{state: _anything}
+      ) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(
+        :signalr_subscribe_timeout,
+        state = %{state: :awaiting_signalr_subscription}
+      ) do
+    {:stop, :signalr_subscribe_timeout, state}
+  end
+
+  def handle_info(
+        :signalr_subscribe_timeout,
+        state = %{state: _anything}
+      ) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(
+        :check_keepalive,
+        state = %{last_keepalive: last_keepalive, keepalive_timeout: timeout}
+      ) do
+    then_sec = DateTime.to_unix(last_keepalive)
+
+    now_sec =
+      DateTime.utc_now()
+      |> DateTime.to_unix()
+
+    sec_since_keepalive = now_sec - then_sec
+
+    if sec_since_keepalive > timeout do
+      {:stop, :keepalive_timeout, state}
+    else
+      {:noreply, state}
+    end
+  end
+
+  defp do_negotiate_signalr_conn(opts) do
+    {:ok, negotiation_data} = SignalRCore.Negotiation.negotiate(opts)
+    negotiation_data
+  end
+
+  defp do_connect_ws(state) do
+    # SignalR Core uses the negotiated connectionToken as the `id` query param.
+    query =
+      %{id: state.signalr_params.conn_token}
+      |> URI.encode_query()
+
+    cookies_header =
+      state.signalr_params.cookies
+      |> Enum.map_join("; ", fn {name, val} -> "#{name}=#{val}" end)
+
+    headers = [
+      {"cookie", cookies_header},
+      {"user-agent", state.user_agent}
+    ]
+
+    ws_scheme =
+      case state.scheme do
+        "https" -> "wss"
+        "http" -> "ws"
+      end
+
+    uri = "#{ws_scheme}://#{state.hostname}:#{state.port}#{state.base_path}?#{query}"
+    ws_state = %{client_pid: self()}
+    ws_opts = [name: SignalRCore.WSClient.name(), headers: headers]
+
+    Logger.info("SignalR: Connecting to websocket at '#{uri}'")
+
+    {:ok, ws_client_pid} =
+      DynamicSupervisor.start_child(
+        @supervisor,
+        {SignalRCore.WSClient, [uri: uri, state: ws_state, opts: ws_opts]}
+      )
+
+    Process.link(ws_client_pid)
+    Logger.info("SignalR: Client started at #{inspect(ws_client_pid)}")
+
+    %{state | ws_client_pid: ws_client_pid, state: :connecting_ws}
+  end
+
+  # SignalR Core: send the protocol handshake immediately after the socket opens.
+  defp do_send_handshake(state) do
+    send_ws_message(%{protocol: "json", version: 1})
+    :timer.send_after(5000, :signalr_init_timeout)
+    %{state | state: :awaiting_handshake}
+  end
+
+  defp do_subscribe_signalr(state) do
+    topics_str = state.topics |> Enum.join(",")
+    Logger.info("SignalR: Subscribing to topics: #{topics_str}")
+
+    msg = %{
+      type: 1,
+      target: "Subscribe",
+      arguments: [state.topics],
+      invocationId: @subscribe_command_id
+    }
+
+    send_ws_message(msg)
+    :timer.send_after(5000, :signalr_subscribe_timeout)
+
+    %{state | state: :awaiting_signalr_subscription}
+  end
+
+  defp send_ws_message(message) do
+    # Each SignalR Core message is terminated by the 0x1e record separator.
+    json = Jason.encode!(message) <> @rs
+    SignalRCore.WSClient.send({:text, json})
+  end
+
+  # A single websocket text frame may bundle several 0x1e-separated messages.
+  defp do_handle_message({:text, raw}, state) do
+    raw
+    |> String.split(@rs, trim: true)
+    |> Enum.reduce(state, &handle_frame/2)
+  end
+
+  defp do_handle_message(_other, state), do: state
+
+  defp handle_frame(frame, state) do
+    case Jason.decode(frame) do
+      {:ok, data} -> dispatch_message(data, state)
+      {:error, _} -> state
+    end
+  end
+
+  # Handshake acknowledgement: an empty object (`{}`) means success.
+  defp dispatch_message(data, state = %{state: :awaiting_handshake})
+       when map_size(data) == 0 do
+    Logger.info("SignalR: handshake complete")
+    do_subscribe_signalr(state)
+  end
+
+  defp dispatch_message(%{"error" => err}, state = %{state: :awaiting_handshake}) do
+    Logger.error("SignalR: handshake rejected: #{inspect(err)}")
+    state
+  end
+
+  # Keep-alive ping (type 6) from the server.
+  defp dispatch_message(%{"type" => 6}, state) do
+    %{state | last_keepalive: DateTime.utc_now()}
+  end
+
+  # Completion of the Subscribe invocation (type 3) carries the initial snapshot.
+  defp dispatch_message(
+         %{"type" => 3, "invocationId" => @subscribe_command_id} = msg,
+         state
+       ) do
+    results = Map.get(msg, "result") || %{}
+
+    for {topic, data} <- results do
+      payload = %Packet{
+        topic: topic,
+        data: data,
+        timestamp: nil,
+        init: true
+      }
+
+      process_packet(payload)
+    end
+
+    subscribed_topics = results |> Map.keys() |> Enum.join(",")
+    Logger.info("SignalR: status changed to subscribed. Topics: #{subscribed_topics}")
+
+    :timer.send_interval(1000, :check_keepalive)
+    :timer.send_interval(10_000, :send_ping)
+
+    %{state | state: :subscribed, last_keepalive: DateTime.utc_now()}
+  end
+
+  # Live feed message (type 1, target "feed").
+  defp dispatch_message(
+         %{"type" => 1, "target" => "feed", "arguments" => arguments},
+         state
+       ) do
+    [topic, data, timestamp | _] = arguments
+
+    topic = String.trim_trailing(topic, ".z")
+    timestamp = F1Bot.DataTransform.Parse.parse_iso_timestamp(timestamp)
+
+    payload = %Packet{
+      topic: topic,
+      data: data,
+      timestamp: timestamp
+    }
+
+    Logger.debug("Received data on topic #{topic}")
+    process_packet(payload)
+
+    %{state | last_keepalive: DateTime.utc_now()}
+  end
+
+  # Server requested the connection be closed (type 7).
+  defp dispatch_message(%{"type" => 7} = msg, state) do
+    Logger.warning("SignalR: server closed the connection: #{inspect(msg)}")
+    state
+  end
+
+  defp dispatch_message(_message, state), do: state
+
+  defp process_packet(payload = %Packet{}) do
+    options = %ProcessingOptions{
+      ignore_reset: false,
+      log_stray_packets: true
+    }
+
+    F1Bot.F1Session.Server.process_live_timing_packet(payload, options)
+  end
+end

--- a/lib/f1_bot/external_api/signalr_core/negotiation.ex
+++ b/lib/f1_bot/external_api/signalr_core/negotiation.ex
@@ -1,0 +1,86 @@
+defmodule F1Bot.ExternalApi.SignalRCore.Negotiation do
+  @moduledoc """
+  HTTP client for SignalR connection negotiation.
+
+  F1 migrated the live timing feed from classic ASP.NET SignalR
+  (`/signalr`, `clientProtocol=1.x`, GET negotiate) to ASP.NET Core SignalR
+  (`/signalrcore`, `negotiateVersion=1`, POST negotiate). The old endpoint now
+  returns HTTP 401. This module implements the Core negotiation.
+
+  Core negotiate protocol:
+  https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md
+  """
+  @finch_instance F1Bot.Finch
+
+  require Logger
+
+  def negotiate(opts) do
+    query =
+      %{negotiateVersion: "1"}
+      |> URI.encode_query()
+
+    base_path = Keyword.fetch!(opts, :base_path)
+
+    url =
+      %URI{
+        scheme: Keyword.fetch!(opts, :scheme),
+        host: Keyword.fetch!(opts, :hostname),
+        port: Keyword.fetch!(opts, :port),
+        path: "#{base_path}/negotiate",
+        query: query
+      }
+      |> URI.to_string()
+
+    Logger.info("Negotiating SignalR (core) at '#{url}'")
+
+    headers = [
+      {"user-agent", Keyword.fetch!(opts, :user_agent)}
+    ]
+
+    # SignalR Core negotiate is a POST with an empty body.
+    Finch.build(:post, url, headers, "")
+    |> Finch.request(@finch_instance, receive_timeout: 5000)
+    |> parse_response()
+  end
+
+  defp parse_response({:ok, %{status: 200, body: body, headers: headers}}) do
+    # F1's load balancer pins the websocket to the same node via the AWSALB
+    # cookie returned here, so we must forward it on the websocket upgrade.
+    cookies =
+      headers
+      |> Enum.filter(fn {name, _v} -> String.downcase(name) == "set-cookie" end)
+      |> Enum.map(fn {_name, val} -> val end)
+      |> Enum.map(fn val -> String.split(val, ";") end)
+      |> Enum.map(fn [val | _] -> val end)
+      |> Enum.map(fn val -> String.split(val, "=", parts: 2) end)
+      |> Enum.map(fn [name, value] -> {name, value} end)
+      |> Enum.into(%{})
+
+    parsed = Jason.decode!(body)
+
+    # Core negotiate (version 1) returns `connectionToken` which must be used as
+    # the `id` query param on the websocket, plus a `connectionId`.
+    conn_token = Map.fetch!(parsed, "connectionToken")
+    conn_id = Map.get(parsed, "connectionId", conn_token)
+
+    response = %{
+      data: %{
+        "ConnectionId" => conn_id,
+        "ConnectionToken" => conn_token
+      },
+      cookies: cookies
+    }
+
+    {:ok, response}
+  end
+
+  defp parse_response({:ok, %{status: status, body: body}}) do
+    Logger.error("SignalR negotiate failed: HTTP #{status} #{inspect(body)}")
+    {:error, {:negotiate_http_error, status}}
+  end
+
+  defp parse_response({:error, reason}) do
+    Logger.error("SignalR negotiate request error: #{inspect(reason)}")
+    {:error, reason}
+  end
+end

--- a/lib/f1_bot/external_api/signalr_core/ws_client.ex
+++ b/lib/f1_bot/external_api/signalr_core/ws_client.ex
@@ -1,0 +1,40 @@
+defmodule F1Bot.ExternalApi.SignalRCore.WSClient do
+  use Fresh, restart: :temporary
+  require Logger
+
+  alias F1Bot.ExternalApi.SignalRCore
+
+  @impl Fresh
+  def handle_connect(_status, _headers, state) do
+    SignalRCore.Client.ws_handle_connected()
+    {:ok, state}
+  end
+
+  @impl Fresh
+  def handle_in(message, state) do
+    # IO.inspect(message, label: "in")
+    SignalRCore.Client.ws_handle_message(message)
+    {:ok, state}
+  end
+
+  @impl Fresh
+  def handle_error(error, _state) do
+    Logger.error("SignalR connection error: #{inspect(error)}")
+
+    {:close, {:error, error}}
+  end
+
+  @impl Fresh
+  def handle_disconnect(code, reason, _state) do
+    Logger.error("SignalR disconnected: #{inspect({code, reason})}")
+
+    {:close, {:error, reason}}
+  end
+
+  def send(message) do
+    # IO.inspect(message, label: "out")
+    Fresh.send(__MODULE__, message)
+  end
+
+  def name, do: {:local, __MODULE__}
+end


### PR DESCRIPTION
Fixes the live timing connection after F1 retired the classic `/signalr` endpoint (now returns HTTP 401) in favour of ASP.NET Core SignalR `/signalrcore`.

## Problem

`GET /signalr/negotiate?clientProtocol=1.x` now returns **401**, so `Negotiation.parse_response/1` raises `FunctionClauseError`, the SignalR client crashes and restarts in a ~2s loop, never receiving any data.

Verified from a clean residential IP:

| Request | Status |
|---|---|
| `GET /signalr/negotiate?clientProtocol=1.5&connectionData=...` | 401 |
| `GET /static/StreamingStatus.json` | 200 (not an IP block) |
| `GET /signalrcore/negotiate?negotiateVersion=1` | 405 (needs POST) |
| `POST /signalrcore/negotiate?negotiateVersion=1` | 200 |

## Changes

- **Negotiation**: `POST /signalrcore/negotiate?negotiateVersion=1`, parse `connectionToken`; still forward the AWSALB sticky-session cookie.
- **Client**: send the JSON protocol handshake, frame messages with the `0x1e` record separator, subscribe via a `type:1 "Subscribe"` invocation, handle the `type:3` completion snapshot, `type:1 "feed"` messages and `type:6` keep-alive pings (and send our own).
- **application.ex**: `base_path` -> `/signalrcore`, non-empty user-agent.

The downstream packet pipeline (`Packet` -> `process_live_timing_packet`) is unchanged. Negotiate succeeds anonymously; no F1 account auth was required.

## Testing

Built and deployed; the client reaches `subscribed`, parses the initial snapshot for all topics and posts to Discord during live sessions, with no crash loop:

```
Negotiating SignalR (core) at 'https://livetiming.formula1.com/signalrcore/negotiate?negotiateVersion=1'
SignalR: Connected to websocket
SignalR: handshake complete
SignalR: Subscribing to topics: TrackStatus,TeamRadio,...
SignalR: status changed to subscribed. Topics: DriverList,ExtrapolatedClock,...,WeatherData
```

_(Supersedes #10, which accidentally bundled unrelated personal feature commits. This one contains only the SignalR Core migration.)_